### PR TITLE
Also build rdkafka with ssl if ssl feature is enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,6 +3082,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ ENV DOCKER_ARCH=${DOCKER_ARCH}
 ENV BUILD_ARCH=${BUILD_ARCH}
 
 ENV BUILD_TARGET=${BUILD_ARCH}-unknown-linux-gnu
+# For native-tls
+ENV OPENSSL_DIR=/usr/local/build/$BUILD_TARGET
+# For rdkafka
+ENV OPENSSL_ROOT_DIR=/usr/local/build/$BUILD_TARGET
+ENV OPENSSL_STATIC=1
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -31,7 +36,9 @@ WORKDIR /work
 FROM getsentry/sentry-cli:1 AS sentry-cli
 FROM relay-deps AS relay-builder
 
-ARG RELAY_FEATURES=ssl,processing,crash-handler
+# ssl and processing are required for basic functionality in onprem
+# kafka-ssl is for free since we already have OpenSSL because we are on Linux
+ARG RELAY_FEATURES=ssl,kafka-ssl,processing,crash-handler
 ENV RELAY_FEATURES=${RELAY_FEATURES}
 
 COPY --from=sentry-cli /bin/sentry-cli /bin/sentry-cli

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ SHELL=/bin/bash
 export RELAY_PYTHON_VERSION := python3
 export RELAY_FEATURES := ssl
 
+# This is the subset of --all-features that actually works on OS X. Notably it
+# is missing kafka-ssl which would require openssl to be installed on OS X.
+export RELAY_DEV_FEATURES := ssl,processing
+
 all: check test
 .PHONY: all
 
@@ -16,7 +20,7 @@ clean:
 # Builds
 
 build: setup-git
-	cargo +stable build --all-features
+	cd relay && cargo +stable build --features ${RELAY_DEV_FEATURES}
 .PHONY: build
 
 release: setup-git
@@ -52,7 +56,7 @@ test-rust: setup-git
 .PHONY: test-rust
 
 test-rust-all: setup-git
-	cargo test --workspace --all-features
+	cargo test --workspace --features ${RELAY_DEV_FEATURES}
 .PHONY: test-rust-all
 
 test-python: setup-git setup-venv

--- a/relay-server/Cargo.toml
+++ b/relay-server/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 [features]
 default = []
 ssl = ["native-tls", "actix-web/tls"]
+kafka-ssl = ["rdkafka/ssl"]
 processing = [
     "minidump",
     "rdkafka",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -11,8 +11,10 @@ license-file = "../LICENSE"
 publish = false
 
 [features]
+# See https://getsentry.github.io/relay/relay/#feature-flags for explanation of feature flags
 default = ["ssl"]
 ssl = ["relay-server/ssl"]
+kafka-ssl = ["relay-server/kafka-ssl"]
 processing = ["relay-server/processing"]
 crash-handler = ["relay-log/crash-handler"]
 

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -21,9 +21,19 @@
 //!
 //! # Feature Flags
 //!
-//! - `ssl` _(default)_: Enables SSL support using `native-tls`.
+//! - `ssl` _(default)_: Enables SSL support for incoming and outgoing HTTP using the [`native-tls`
+//!   crate](https://crates.io/crates/native-tls). On Windows/Mac this will use the native SSL
+//!   capabilities while for other platforms OpenSSL is required.
+//!
+//!   Disable this feature to remove the dependency on OpenSSL under Linux.
+//!
 //! - `processing`: Includes event ingestion and processing functionality. This should only be
-//!   specified when compiling Relay as Sentry service. Standalone Relays do not need this feature.
+//!   specified when compiling Relay as Sentry service.  Standalone Relays do not need this feature.
+//!
+//! - `kafka-ssl`: This feature is only relevant in combination with `processing`.
+//!   The Kafka client `librdkafka` requires OpenSSL on *all* platforms to speak SSL.
+//!   As this is an extra requirement on Windows and Mac, this is disabled by default.
+
 //!
 //! # Workspace Crates
 //!


### PR DESCRIPTION
This restores support for SSL for Kafka, removed upstream in https://github.com/getsentry/relay/pull/889 - we need SSL support to securely communicate with Aiven for Apache Kafka services. In https://github.com/getsentry/relay/issues/971#issuecomment-813961821 Sentry folks suggested forking and reverting the upstream removal, if Kafka SSL support is needed, hence taking this approach. 

#skip-changelog

This reverts commit 69399c8c177b73282b808e0147005e1d8aae406b.