### PR TITLE
github: build Docker image with GH Action [SREEU-520]

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,45 @@
+name: Docker Image Build
+
+on:
+  push:
+    branches:
+      - release-docker/**
+    tags:
+      - aiven-*
+  pull_request:
+
+jobs:
+  build_docker:
+    name: Build Docker image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Get version from the Git tag
+        id: get_version
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]
+          then
+            # If building a tag, use the same tag for the image
+            echo ::set-output name=tag_version::${GITHUB_REF/refs\/tags\//}
+          else
+            echo ::set-output name=tag_version::${{ github.event.pull_request.head.sha || github.sha }}
+          fi
+
+      - name: Log in to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image and push if tagged
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/aiven/relay:${{ steps.get_version.outputs.tag_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
         id: setup
         run: |
           # GITHUB_SHA in pull requests points to the merge commit
-          RELAY_TEST_IMAGE=us.gcr.io/sentryio/relay:${{ github.event.pull_request.head.sha || github.sha }}
+          RELAY_TEST_IMAGE=ghcr.io/aiven/relay:${{ github.event.pull_request.head.sha || github.sha }}
           echo "We expected GCB to push this image $RELAY_TEST_IMAGE"
           echo "::set-output name=relay-test-image::$RELAY_TEST_IMAGE"
           # We cannot execute actions that are not placed under .github of the main repo

--- a/README.md
+++ b/README.md
@@ -239,6 +239,24 @@ port in the DSN:
 http://<key>@localhost:3001/<id>
 ```
 
+### Docker images
+
+This repository contains a Dockerfile which can be used to build an image to run
+Relay:
+
+```bash
+docker build -t my-relay-image .
+```
+
+Images built from this repository are also published to Github Container
+Registry and can be pulled from there:
+
+```bash
+docker pull ghcr.io/aiven/relay:<git commit-SHA or tag>
+```
+
+This is specific to the fork https://github.com/aiven/relay.
+
 ### Release Management
 
 We use [craft](https://github.com/getsentry/craft) to release new versions.


### PR DESCRIPTION
This adds a workflow to automate building of a Docker image from our fork, and publishing it to Github Container Repository. This will let us eliminate [this awkward part](https://github.com/aiven/cloud_infra_tf_ovh/blob/eb75ed27f6d2ccb067ea085369da274c0541b20e/ovh/modules/sentry_container_host/README.md?plain=1#L12-L21) of the self-hosted Sentry setup where we build an image locally and push it to the target host; the target host can pull the image from ghcr.io instead.

#skip-changelog
